### PR TITLE
Fix <<-EOS.undent deprecation

### DIFF
--- a/parity.rb
+++ b/parity.rb
@@ -36,7 +36,7 @@ class Parity < Formula
     system "#{bin}/delta", "--version"
   end
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
I got the following warning while installing:

> Use <<~EOS instead.
> /usr/local/Homebrew/Library/Taps/paritytech/homebrew-paritytech/parity.rb:61:in `plist'
> Please report this to the paritytech/paritytech tap!

Closes #68