### PR TITLE
Formula fixes

### DIFF
--- a/parity.rb
+++ b/parity.rb
@@ -2,23 +2,20 @@ require 'formula'
 
 class Parity < Formula
   homepage 'https://github.com/paritytech/parity'
+  version '1.8.11'
+  url 'https://d1h4xl4cr1h0mo.cloudfront.net/v1.8.11/x86_64-apple-darwin/parity'
+  sha256 "e52e16b11f25cc8900349df04b0ce9b22bb85372029e67608153ae5ea9e02af4"
 
-  if build.include? "master" or build.include? "nightly"
-    version '1.10.0'
-    url 'https://d1h4xl4cr1h0mo.cloudfront.net/nightly/x86_64-apple-darwin/parity'
-  elsif build.include? "beta" or build.include? "latest"
+  devel do
     version '1.9.4'
     url 'https://d1h4xl4cr1h0mo.cloudfront.net/v1.9.4/x86_64-apple-darwin/parity'
     sha256 "95ee40205278776f03918178e554e67c36177bfa53bb09a5c22fe5ca08dc1c36"
-  else
-    version '1.8.11'
-    url 'https://d1h4xl4cr1h0mo.cloudfront.net/v1.8.11/x86_64-apple-darwin/parity'
-    sha256 "e52e16b11f25cc8900349df04b0ce9b22bb85372029e67608153ae5ea9e02af4"
   end
 
-  option 'nightly', 'Install nightly version.'
-  option 'beta', 'Install latest beta.'
-  option 'stable', 'Install latest stable (default).'
+  head do
+    version '1.10.0'
+    url 'https://d1h4xl4cr1h0mo.cloudfront.net/nightly/x86_64-apple-darwin/parity'
+  end
 
   bottle :unneeded
 

--- a/parity.rb
+++ b/parity.rb
@@ -17,8 +17,6 @@ class Parity < Formula
     url 'https://d1h4xl4cr1h0mo.cloudfront.net/nightly/x86_64-apple-darwin/parity'
   end
 
-  bottle :unneeded
-
   def install
     bin.install "parity"
   end

--- a/parity.rb
+++ b/parity.rb
@@ -30,6 +30,8 @@ class Parity < Formula
     system "#{bin}/delta", "--version"
   end
 
+  plist_options :manual => "parity"
+
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -43,6 +45,10 @@ class Parity < Formula
         <true/>
         <key>ThrottleInterval</key>
         <integer>300</integer>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{prefix}/bin/parity</string>
+        </array>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>
       </dict>


### PR DESCRIPTION
- Fixes the formula plist
- Uses homebrew's proper support for setting up stable, development and HEAD versions

The existing formula wasn't working properly for me. Even though I installed with `--beta`, homebrew would assume that I had the stable version installed and I had errors like this: 

`Warning: Skipping paritytech/paritytech/parity: most recent version 1.8.11 not installed`

With these changes homebrew properly detects the existing versions:

```
❯ brew info parity
paritytech/paritytech/parity: stable 1.8.11, devel 1.9.4, HEAD
https://github.com/paritytech/parity
/usr/local/Cellar/parity/1.9.4 (4 files, 51.0MB) *
  Built from source on 2018-03-07 at 13:03:03
From: https://github.com/paritytech/homebrew-paritytech/blob/master/parity.rb
==> Options
--devel
        Install development version 1.9.4
--HEAD
        Install HEAD version
==> Caveats
To have launchd start paritytech/paritytech/parity now and restart at login:
  brew services start paritytech/paritytech/parity
Or, if you don't want/need a background service you can just run:
  parity
```